### PR TITLE
featuer/member_leave

### DIFF
--- a/src/main/java/com/ormi5/movieblog/usercontroller/UserController.java
+++ b/src/main/java/com/ormi5/movieblog/usercontroller/UserController.java
@@ -1,14 +1,17 @@
 package com.ormi5.movieblog.usercontroller;
 
 import com.ormi5.movieblog.user.ProfileResponseDto;
+import com.ormi5.movieblog.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.security.Principal;
 
 @Controller
 @RequestMapping("/user")
@@ -25,5 +28,18 @@ public class UserController {
 		model.addAttribute("user", userService.getUserProfile(userId));
 
 		return "user/user";
+	}
+
+	/**
+	 * 회원 탈퇴를 실행하는 메서드
+	 * @param principal 현재 로그인한 사용자의 username을 가져옴
+	 * @return 메인 페이지로 이동
+	 */
+	@PostMapping("/delete")
+	public String leaveMember(Principal principal) {
+		userService.leaveMember(principal.getName());
+		// 유저를 삭제한 후 강제 로그아웃
+		new SecurityContextLogoutHandler().logout(((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest(), null, null);
+		return "/home";
 	}
 }

--- a/src/main/java/com/ormi5/movieblog/usercontroller/UserService.java
+++ b/src/main/java/com/ormi5/movieblog/usercontroller/UserService.java
@@ -139,4 +139,14 @@ public class UserService {
 			return target;
 		});
 	}
+
+	/**
+	 * 데이터베이스에서 User 정보를 삭제함
+	 * @param username 삭제할(현재 로그인중인) username
+	 */
+	@Transactional
+	public void leaveMember(String username) {
+		User user = userRepository.findByUsername(username);
+		userRepository.delete(user);
+	}
 }

--- a/src/main/resources/templates/user/user.html
+++ b/src/main/resources/templates/user/user.html
@@ -7,7 +7,6 @@
     <meta id="_csrf_header" name="_csrf_header" th:content="${_csrf?.headerName}"/>
 </head>
 <body>
-    <!--/*@thymesVar id="user" type="com.ormi5.movieblog.post.PostResponseDto"*/-->
     <div th:object="${user}">
         <h1 th:text="*{username}"></h1>
         <a th:href="@{/board}">돌아가기</a>
@@ -29,8 +28,6 @@
             </tr>
             </thead>
             <tbody>
-            <!--/*@thymesVar id="user.postList" type="java.util.ArrayList<>"*/-->
-            <!--/*@thymesVar id="post" type="com.ormi5.movieblog.post.ProfilePostResponseDto"*/-->
             <tr th:each="post : *{postList}">
                 <td th:text="${post.title}"></td>
                 <td th:text="${#temporals.format(post.createAt, 'yyyy.MM.dd HH:mm')}"></td>
@@ -41,6 +38,11 @@
             </tr>
             </tbody>
         </table>
+        <div>
+            <form th:action="@{'/user/delete'}" method="post">
+                <button type="submit">회원 탈퇴</button>
+            </form>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
- #54 
- 회원 탈퇴 기능 개발
- 회원 탈퇴 시, DB에서 회원 컬럼 삭제
- CASCADE 적용하여 회원이 작성한 Post, Comment 모두 삭제 되게 함(재가입 가능)

DB에 CASCADE 속성을 적용해야 해서 local 각자 DB에서 돌리시면 오류가 납니다.
AWS Lightsail에 배포해 놓은 DB로는 적용이 되어있으니 참고 부탁드립니다.